### PR TITLE
Add including "functional" in threadpool.h

### DIFF
--- a/FFX_CAS/cas-samples/libs/cauldron/src/common/Misc/threadpool.h
+++ b/FFX_CAS/cas-samples/libs/cauldron/src/common/Misc/threadpool.h
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <deque>
 #include <condition_variable>
+#include <functional>
 
 struct Task
 {


### PR DESCRIPTION
When I build sample project in Visual Studio 2019, an error occurred due to the <functional> header file is missing in .\FFX_CAS\libs\cauldron\src\common\Misc\threadpool.h.
It would be nice to add a line including <functional> header file.